### PR TITLE
AmazonAPIのupdate対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@
 /config/master.key
 
 .env
+
+/vendor/bundle

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'bootstrap', '~> 4.0.0.beta2.1'
 gem 'jquery-rails'
 
 # Amazon API
-gem 'amazon-ecs'
+gem 'vacuum'
 
 gem "font-awesome-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,14 +55,14 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
-    amazon-ecs (2.5.0)
-      nokogiri (~> 1.4)
-      ruby-hmac (~> 0.3)
     archive-zip (0.11.0)
       io-like (~> 0.3.0)
     arel (9.0.0)
     autoprefixer-rails (9.4.3)
       execjs
+    aws-eventstream (1.0.3)
+    aws-sigv4 (1.1.1)
+      aws-eventstream (~> 1.0, >= 1.0.2)
     better_errors (2.5.0)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
@@ -117,6 +117,9 @@ GEM
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     fission (0.5.0)
       CFPropertyList (~> 2.2)
     fog (2.1.0)
@@ -295,8 +298,16 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.7)
+    http (4.3.0)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      http-parser (~> 1.2.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
+    http-form_data (2.3.0)
+    http-parser (1.2.1)
+      ffi-compiler (>= 1.0, < 2.0)
     httpclient (2.8.3)
     i18n (1.3.0)
       concurrent-ruby (~> 1.0)
@@ -412,7 +423,6 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retriable (3.1.2)
-    ruby-hmac (0.4.0)
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
     sass (3.7.2)
@@ -461,6 +471,9 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
+    vacuum (3.3.0)
+      aws-sigv4 (~> 1.0)
+      http (~> 4.0)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -478,7 +491,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  amazon-ecs
   better_errors
   binding_of_caller
   bootsnap (>= 1.1.0)
@@ -508,6 +520,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
+  vacuum
   web-console (>= 3.3.0)
 
 RUBY VERSION

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -56,26 +56,23 @@ class PostsController < ApplicationController
   private
 
   def search_by_amazon(keyword)
-    # デバッグ出力用/trueで出力
-    Amazon::Ecs.debug = false
-
     # AmazonAPIで検索
-    results = Amazon::Ecs.item_search(
-      keyword,
-      search_index:  'Books',
-      dataType: 'script',
-      response_group: 'ItemAttributes, Images',
-      country:  'jp',
-      power: 'Not kindle'
-    )
+    request = Vacuum.new(marketplace: 'JP',
+                         access_key: ENV['AMAZON_API_ACCESS_KEY'],
+                         secret_key: ENV['AMAZON_API_SECRET_KEY'],
+                         partner_tag: ENV['ASSOCIATE_TAG'])
+    response = request.search_items(keywords: keyword,
+                                    search_index: 'Books',
+                                    resources: ['ItemInfo.Title', 'Images.Primary.Large']).to_h
+    items = response.dig('SearchResult', 'Items')
 
     # 検索結果から本のタイトル,画像URL, 詳細ページURLの取得
     books = []
-    results.items.each do |item|
+    items.each do |item|
       book = {
-        title: item.get('ItemAttributes/Title'),
-        image: item.get('LargeImage/URL'),
-        url: item.get('DetailPageURL'),
+        title: item.dig('ItemInfo', 'Title', 'DisplayValue'),
+        image: item.dig('Images', 'Primary', 'Large', 'URL'),
+        url: item.dig('DetailPageURL')
       }
       books << book
     end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,9 +3,3 @@ require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!
-
-Amazon::Ecs.options = {
-  associate_tag: ENV['ASSOCIATE_TAG'],
-  AWS_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
-  AWS_secret_key: ENV['AWS_SECRET_KEY']
-}


### PR DESCRIPTION
> 現在AmazonのProduct Advertising API (PA-API) をお使いの方は、2020年3月9日までにPA-API 4.0に対してシステムコールを行うすべてのアプリケーションの Amazon Product Advertising API version 5.0 (PA-API 5.0)へのアップグレードをお済ませください。

- 公式以降ガイド：https://affiliate.amazon.co.jp/help/node/topic/GZH32YX29UH5GACM

- 使用gemを決めた記事：https://portalshit.net/2020/01/26/migrate-to-amazon-pa-api-5-0

- 移行した記事（めっちゃ参考になった）：https://crieit.net/posts/PAAPI-v5-Node-js

- ItemSearchの仕様：https://docs.aws.amazon.com/AWSECommerceService/latest/DG/ItemSearch.html